### PR TITLE
Harden chat session management for the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ For unstable multi-agent version, you also can run:
 python run_flow.py
 ```
 
+### Web interface (experimental)
+
+To try the browser-based experience, start the FastAPI server:
+
+```bash
+uvicorn app.web.server:app --reload
+```
+
+Then open <http://localhost:8000> to access the chat UI. Each browser tab keeps its
+own session and conversations are stored in memory while the server is running.
+
+
 ### Custom Adding Multiple Agents
 
 Currently, besides the general OpenManus Agent, we have also integrated the DataAnalysis Agent, which is suitable for data analysis and data visualization tasks. You can add this agent to `run_flow` in `config.toml`.

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,28 +1,70 @@
+import logging
 import sys
 from datetime import datetime
+from importlib.util import find_spec
+from pathlib import Path
 
-from loguru import logger as _logger
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-from app.config import PROJECT_ROOT
+
+if find_spec("loguru") is not None:
+    from loguru import logger as _logger  # type: ignore[import-not-found]
+
+    _loguru_available = True
+else:  # pragma: no cover - loguru expected in production environments
+    _loguru_available = False
+    _logger = logging.getLogger("app")
 
 
 _print_level = "INFO"
 
 
-def define_log_level(print_level="INFO", logfile_level="DEBUG", name: str = None):
-    """Adjust the log level to above level"""
+def define_log_level(
+    print_level: str = "INFO", logfile_level: str = "DEBUG", name: str | None = None
+):
+    """Configure the application logger with sane defaults.
+
+    Uses *loguru* when available for richer logging capabilities while
+    gracefully falling back to the standard :mod:`logging` module when the
+    dependency is missing (for example in lightweight environments).
+    """
+
     global _print_level
     _print_level = print_level
 
     current_date = datetime.now()
     formatted_date = current_date.strftime("%Y%m%d%H%M%S")
-    log_name = (
-        f"{name}_{formatted_date}" if name else formatted_date
-    )  # name a log with prefix name
+    log_name = f"{name}_{formatted_date}" if name else formatted_date
 
-    _logger.remove()
-    _logger.add(sys.stderr, level=print_level)
-    _logger.add(PROJECT_ROOT / f"logs/{log_name}.log", level=logfile_level)
+    log_dir: Path = PROJECT_ROOT / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    if _loguru_available:
+        _logger.remove()
+        _logger.add(sys.stderr, level=print_level)
+        _logger.add(log_dir / f"{log_name}.log", level=logfile_level)
+    else:
+        _logger.setLevel(getattr(logging, logfile_level.upper(), logging.DEBUG))
+
+        for handler in list(_logger.handlers):
+            _logger.removeHandler(handler)
+
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setLevel(getattr(logging, print_level.upper(), logging.INFO))
+        stream_handler.setFormatter(formatter)
+
+        file_handler = logging.FileHandler(log_dir / f"{log_name}.log")
+        file_handler.setLevel(getattr(logging, logfile_level.upper(), logging.DEBUG))
+        file_handler.setFormatter(formatter)
+
+        _logger.addHandler(stream_handler)
+        _logger.addHandler(file_handler)
+
     return _logger
 
 

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -1,0 +1,234 @@
+"""Minimal FastAPI server exposing the Manus agent over HTTP."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+from app.agent.manus import Manus
+from app.logger import logger
+
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+class MessageEnvelope(BaseModel):
+    """Serializable representation of a chat message."""
+
+    role: str = Field(pattern=r"^(user|assistant)$")
+    content: str
+
+
+class MessageRequest(BaseModel):
+    """Incoming user message payload."""
+
+    text: str = Field(..., min_length=1, max_length=2000)
+
+
+class MessageResponse(BaseModel):
+    """Response returned after the agent processes a message."""
+
+    chat_id: str
+    reply: str
+    steps: List[str]
+    messages: List[MessageEnvelope]
+    title: str | None = None
+
+
+class CreateChatRequest(BaseModel):
+    """Optional payload when creating a chat session."""
+
+    title: str | None = None
+
+
+class CreateChatResponse(BaseModel):
+    """Response payload containing a new chat identifier."""
+
+    chat_id: str
+
+
+class ChatDetailResponse(BaseModel):
+    """Full representation of a chat session."""
+
+    chat_id: str
+    title: str | None = None
+    messages: List[MessageEnvelope]
+
+
+@dataclass
+class ChatSession:
+    """In-memory representation of a chat session."""
+
+    chat_id: str = field(default_factory=lambda: uuid4().hex)
+    title: str | None = None
+    agent: Manus | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    messages: List[MessageEnvelope] = field(default_factory=list)
+
+    def clone_messages(self) -> List[MessageEnvelope]:
+        """Return a deep copy of stored messages to avoid shared references."""
+
+        return [message.model_copy(deep=True) for message in self.messages]
+
+    def snapshot(self) -> ChatDetailResponse:
+        """Produce a serializable representation of the chat session."""
+
+        return ChatDetailResponse(
+            chat_id=self.chat_id,
+            title=self.title,
+            messages=self.clone_messages(),
+        )
+
+    async def ensure_agent(self) -> Manus:
+        """Instantiate the Manus agent lazily for the session."""
+
+        if self.agent is None:
+            logger.info("Creating Manus agent for chat %s", self.chat_id)
+            self.agent = await Manus.create()
+        return self.agent
+
+    async def handle_message(self, text: str) -> tuple[str, List[str]]:
+        """Append the user message, invoke the agent and store the reply."""
+
+        self.messages.append(MessageEnvelope(role="user", content=text))
+        if not self.title:
+            snippet = text.strip()
+            if snippet:
+                self.title = snippet[:30] + ("..." if len(snippet) > 30 else "")
+        agent = await self.ensure_agent()
+
+        try:
+            summary = await agent.run(text)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Failed to run Manus for chat %s", self.chat_id)
+            raise HTTPException(status_code=500, detail="Agent execution failed") from exc
+
+        summary = summary or ""
+
+        assistant_messages = [
+            msg.content
+            for msg in agent.memory.messages
+            if msg.role == "assistant" and msg.content
+        ]
+        reply = assistant_messages[-1] if assistant_messages else summary
+        self.messages.append(MessageEnvelope(role="assistant", content=reply))
+
+        steps = [line.strip() for line in summary.splitlines() if line.strip()]
+        return reply, steps
+
+    async def close(self) -> None:
+        """Dispose of agent resources associated with the chat."""
+
+        if self.agent is not None:
+            try:
+                await self.agent.cleanup()
+            except Exception:  # pragma: no cover - best effort cleanup
+                logger.exception("Error cleaning up Manus for chat %s", self.chat_id)
+            finally:
+                self.agent = None
+
+
+def _create_application() -> FastAPI:
+    """Build the FastAPI application used to expose the HTTP interface."""
+
+    sessions: Dict[str, ChatSession] = {}
+    sessions_lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        try:
+            yield
+        finally:
+            # Ensure all sessions release resources when the server stops.
+            async with sessions_lock:
+                pending_sessions = list(sessions.values())
+                sessions.clear()
+
+            for session in pending_sessions:
+                await session.close()
+
+    app = FastAPI(title="OpenManus Server", version="1.0.0", lifespan=lifespan)
+
+    # Allow usage from local tooling without additional reverse proxies.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    if STATIC_DIR.exists():
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+    @app.post("/api/chats", response_model=CreateChatResponse)
+    async def create_chat(request: CreateChatRequest | None = None) -> CreateChatResponse:
+        session = ChatSession(title=(request.title if request else None))
+        async with sessions_lock:
+            sessions[session.chat_id] = session
+        logger.info("Created chat %s", session.chat_id)
+        return CreateChatResponse(chat_id=session.chat_id)
+
+    @app.get("/api/chats", response_model=List[ChatDetailResponse])
+    async def list_chats() -> List[ChatDetailResponse]:
+        async with sessions_lock:
+            snapshot = list(sessions.values())
+
+        return [session.snapshot() for session in snapshot]
+
+    @app.get("/api/chats/{chat_id}", response_model=ChatDetailResponse)
+    async def get_chat(chat_id: str) -> ChatDetailResponse:
+        async with sessions_lock:
+            session = sessions.get(chat_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Chat not found")
+        return session.snapshot()
+
+    @app.delete("/api/chats/{chat_id}", status_code=204)
+    async def delete_chat(chat_id: str) -> Response:
+        async with sessions_lock:
+            session = sessions.pop(chat_id, None)
+        if session is None:
+            return Response(status_code=204)
+        await session.close()
+        logger.info("Deleted chat %s", chat_id)
+        return Response(status_code=204)
+
+    @app.post("/api/chats/{chat_id}/messages", response_model=MessageResponse)
+    async def post_message(chat_id: str, payload: MessageRequest) -> MessageResponse:
+        async with sessions_lock:
+            session = sessions.get(chat_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Chat not found")
+
+        async with session.lock:
+            reply, steps = await session.handle_message(payload.text)
+            return MessageResponse(
+                chat_id=chat_id,
+                reply=reply,
+                steps=steps,
+                messages=session.clone_messages(),
+                title=session.title,
+            )
+
+    @app.get("/")
+    async def index() -> FileResponse:
+        if not STATIC_DIR.exists():
+            raise HTTPException(status_code=404, detail="Static assets missing")
+        return FileResponse(STATIC_DIR / "index.html")
+
+    return app
+
+
+app = _create_application()
+
+__all__ = ["app"]

--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -1,0 +1,704 @@
+<!DOCTYPE html>
+<html lang="pt-br" class="">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OpenManus</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        :root {
+            --sidebar-bg: #f9fafb;
+            --main-bg: #ffffff;
+            --text-primary: #1f2937;
+            --text-secondary: #6b7280;
+            --border-color: #e5e7eb;
+            --input-bg: #ffffff;
+            --user-msg-bg: #dbeafe;
+            --user-msg-text: #1e40af;
+            --ai-msg-bg: #f3f4f6;
+            --ai-msg-text: #1f2937;
+            --button-hover: #f3f4f6;
+            --code-bg: #e5e7eb;
+        }
+        ::-webkit-scrollbar { width: 8px; }
+        ::-webkit-scrollbar-track { background: var(--sidebar-bg); }
+        ::-webkit-scrollbar-thumb { background: #d1d5db; border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: #9ca3af; }
+        body { font-family: 'Inter', sans-serif; background-color: var(--sidebar-bg); }
+        .sidebar { background-color: var(--sidebar-bg); }
+        .main-content { background-color: var(--main-bg); color: var(--text-primary); }
+        .text-primary { color: var(--text-primary); }
+        .text-secondary { color: var(--text-secondary); }
+        .border-custom { border-color: var(--border-color); }
+        .input-bg { background-color: var(--input-bg); }
+        .user-message { background-color: var(--user-msg-bg); color: var(--user-msg-text); position: relative; }
+        .ai-message { background-color: var(--ai-msg-bg); color: var(--ai-msg-text); position: relative; }
+        .btn-hover:hover { background-color: var(--button-hover); }
+        .btn-active { background-color: var(--button-hover) !important; }
+        .user-message::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            right: -8px;
+            transform: translateY(-50%);
+            width: 0;
+            height: 0;
+            border-top: 8px solid transparent;
+            border-bottom: 8px solid transparent;
+            border-left: 8px solid var(--user-msg-bg);
+        }
+        .ai-message-bubble::before {
+            content: '';
+            position: absolute;
+            top: 18px;
+            left: -8px;
+            transform: translateY(-50%);
+            width: 0;
+            height: 0;
+            border-top: 8px solid transparent;
+            border-bottom: 8px solid transparent;
+            border-right: 8px solid var(--ai-msg-bg);
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        .animate-spin-slow { animation: spin 2s linear infinite; }
+        .prose { line-height: 1.7; }
+        .prose pre { padding: 1rem; border-radius: 0.5rem; overflow-x: auto; background-color: var(--code-bg); }
+        .prose code { font-family: 'Courier New', Courier, monospace; }
+        .prose ul { list-style-type: disc; padding-left: 1.5rem; }
+        .prose strong { font-weight: 600; }
+        .sidebar-item:hover .delete-btn { opacity: 1; }
+        .delete-btn { opacity: 0; transition: opacity 0.2s; }
+        .modal, .modal-overlay { transition: opacity 0.3s ease-in-out; }
+        .modal-content { transition: transform 0.3s ease-in-out; }
+    </style>
+</head>
+<body class="antialiased text-primary">
+    <div class="flex h-screen overflow-hidden">
+        <aside id="sidebar" class="sidebar w-64 flex-col flex-shrink-0 border-r border-custom transition-transform duration-300 ease-in-out flex fixed inset-y-0 left-0 z-30 md:relative md:z-auto md:translate-x-0 transform -translate-x-full">
+            <div class="flex items-center justify-between p-3 h-16 border-b border-custom flex-shrink-0">
+                <a href="#" class="flex items-center gap-2 font-semibold text-lg truncate">
+                    <i class="fa-solid fa-robot text-gray-500"></i>
+                    <span class="sidebar-text">OpenManus</span>
+                </a>
+                <button id="sidebar-toggle" class="p-2 rounded-md btn-hover text-secondary hidden md:block" title="Recolher menu">
+                    <i class="fa-solid fa-chevron-left"></i>
+                </button>
+            </div>
+            <div class="flex-1 overflow-y-auto p-2">
+                <a href="#" id="new-chat-btn" class="flex items-center gap-3 p-3 rounded-lg font-medium btn-hover" title="Iniciar um novo chat">
+                    <i class="fa-regular fa-pen-to-square text-lg w-6 text-center"></i>
+                    <span class="sidebar-text">Novo chat</span>
+                </a>
+                <div class="mt-4">
+                    <h2 class="px-3 text-xs font-semibold text-secondary uppercase tracking-wider sidebar-text">Recentes</h2>
+                    <div id="recent-chats-container" class="mt-2 space-y-1"></div>
+                </div>
+            </div>
+            <div class="border-t border-custom p-2 flex-shrink-0">
+                <a href="#" class="flex items-center gap-3 p-3 rounded-lg text-sm font-medium btn-hover">
+                    <img src="https://placehold.co/32x32/667eea/ffffff?text=U" alt="User Avatar" class="w-8 h-8 rounded-full">
+                    <span class="sidebar-text">Meu Plano</span>
+                </a>
+            </div>
+        </aside>
+        <div class="flex-1 flex flex-col min-w-0">
+            <header class="flex items-center justify-between p-4 flex-shrink-0 bg-main">
+                <div class="flex items-center gap-2">
+                    <button id="menu-toggle" class="p-2 rounded-md btn-hover md:hidden" title="Abrir menu"><i class="fa-solid fa-bars"></i></button>
+                    <div id="mode-switcher-container" class="bg-gray-200 p-1 rounded-lg flex items-center text-sm font-medium">
+                        <button id="chat-mode-btn" data-mode="chat" class="mode-btn px-3 py-1 rounded-md transition-colors">Chat Mode</button>
+                        <button id="agent-mode-btn" data-mode="agent" class="mode-btn px-3 py-1 rounded-md transition-colors">Agent Mode</button>
+                    </div>
+                </div>
+                <div class="flex items-center gap-2">
+                    <button class="p-2 rounded-md btn-hover text-secondary" title="Mais opções"><i class="fa-solid fa-ellipsis"></i></button>
+                </div>
+            </header>
+            <main class="main-content flex-1 flex relative overflow-hidden">
+                <div id="chat-container" class="flex-1 overflow-y-auto p-4 md:p-6 min-w-0"></div>
+                <button id="scroll-to-bottom" class="hidden absolute right-8 bottom-8 z-10 w-10 h-10 rounded-full border border-custom bg-white/70 backdrop-blur-sm text-secondary btn-hover"><i class="fa-solid fa-arrow-down"></i></button>
+            </main>
+            <div id="chat-input-container" class="p-4 md:p-6">
+                <div class="max-w-3xl mx-auto">
+                    <form id="chat-form" class="relative">
+                        <textarea id="chat-input" rows="1" class="w-full pl-12 pr-20 py-3 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 input-bg text-primary transition-all shadow-lg" placeholder="Pergunte alguma coisa..."></textarea>
+                        <div class="absolute left-4 top-1/2 -translate-y-1/2">
+                            <button type="button" id="attach-btn" class="p-2 rounded-full btn-hover text-secondary" title="Anexar ficheiro"><i class="fa-solid fa-paperclip"></i></button>
+                        </div>
+                        <div class="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-2">
+                            <button type="button" class="p-2 rounded-full btn-hover text-secondary" title="Usar microfone"><i class="fa-solid fa-microphone"></i></button>
+                            <button id="send-btn" type="submit" class="p-2 w-10 h-10 flex items-center justify-center rounded-full bg-gray-200 text-gray-400 transition-colors" disabled title="Enviar mensagem"><i class="fa-solid fa-arrow-up"></i></button>
+                        </div>
+                    </form>
+                    <p class="text-xs text-center text-secondary mt-2">O OpenManus pode cometer erros. Por isso, lembre-se de conferir informações relevantes.</p>
+                </div>
+            </div>
+        </div>
+        <div id="sidebar-backdrop" class="fixed inset-0 bg-black bg-opacity-50 z-20 hidden md:hidden"></div>
+    </div>
+    <div id="modals-container"></div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const API_BASE = '/api';
+            const STORAGE_KEY = 'openmanus_state';
+            const DOM = {
+                body: document.body,
+                chatContainer: document.getElementById('chat-container'),
+                chatForm: document.getElementById('chat-form'),
+                chatInput: document.getElementById('chat-input'),
+                sendBtn: document.getElementById('send-btn'),
+                menuToggle: document.getElementById('menu-toggle'),
+                sidebar: document.getElementById('sidebar'),
+                sidebarBackdrop: document.getElementById('sidebar-backdrop'),
+                newChatButton: document.getElementById('new-chat-btn'),
+                recentChatsContainer: document.getElementById('recent-chats-container'),
+                scrollToBottomBtn: document.getElementById('scroll-to-bottom'),
+                chatModeBtn: document.getElementById('chat-mode-btn'),
+                agentModeBtn: document.getElementById('agent-mode-btn'),
+                modalsContainer: document.getElementById('modals-container')
+            };
+
+            const state = {
+                chats: [],
+                currentChatId: null,
+                currentMode: 'chat'
+            };
+
+            const app = {
+                async init() {
+                    this.loadState();
+                    this.bindEventListeners();
+                    sidebar.init();
+                    await this.syncChatsFromServer();
+                    if (!state.currentChatId && state.chats.length) {
+                        state.currentChatId = state.chats[0].id;
+                        this.saveState();
+                    }
+                    ui.renderSidebar();
+                    ui.renderCurrentChat();
+                    ui.updateForMode();
+                },
+                loadState() {
+                    try {
+                        const savedState = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+                        state.currentChatId = savedState.currentChatId || null;
+                        state.currentMode = savedState.currentMode || 'chat';
+                    } catch (error) {
+                        console.error('Erro ao carregar preferências locais:', error);
+                        state.currentChatId = null;
+                        state.currentMode = 'chat';
+                    }
+                },
+                saveState() {
+                    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+                        currentChatId: state.currentChatId,
+                        currentMode: state.currentMode
+                    }));
+                },
+                bindEventListeners() {
+                    DOM.chatInput.addEventListener('input', handlers.handleInput);
+                    DOM.chatInput.addEventListener('keydown', handlers.handleKeydown);
+                    DOM.chatForm.addEventListener('submit', (event) => {
+                        event.preventDefault();
+                        handlers.handleFormSubmit(event);
+                    });
+                    DOM.newChatButton.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        handlers.startNewChat();
+                    });
+                    DOM.recentChatsContainer.addEventListener('click', (event) => {
+                        handlers.handleSidebarClick(event);
+                    });
+                    DOM.menuToggle.addEventListener('click', sidebar.openMobile);
+                    DOM.sidebarBackdrop.addEventListener('click', sidebar.closeMobile);
+                    DOM.chatContainer.addEventListener('scroll', handlers.handleScroll);
+                    DOM.scrollToBottomBtn.addEventListener('click', () => DOM.chatContainer.scrollTo({ top: DOM.chatContainer.scrollHeight, behavior: 'smooth' }));
+                    DOM.chatModeBtn.addEventListener('click', () => this.setMode('chat'));
+                    DOM.agentModeBtn.addEventListener('click', () => this.setMode('agent'));
+                },
+                async syncChatsFromServer() {
+                    try {
+                        const response = await fetch(`${API_BASE}/chats`);
+                        if (!response.ok) {
+                            throw new Error(`Erro ${response.status}`);
+                        }
+                        const data = await response.json();
+                        const refreshed = (Array.isArray(data) ? data : []).map((item) => ({
+                            id: item.chat_id,
+                            title: item.title || 'Nova conversa',
+                            messages: (item.messages || []).map((msg) => ({
+                                role: msg.role,
+                                content: msg.content,
+                                type: 'text'
+                            }))
+                        }));
+                        const hasCurrent = refreshed.some((chat) => chat.id === state.currentChatId);
+                        state.chats = refreshed;
+                        if (state.currentChatId && !hasCurrent) {
+                            state.currentChatId = state.chats.length ? state.chats[0].id : null;
+                        }
+                    } catch (error) {
+                        console.error('Não foi possível sincronizar os chats', error);
+                        if (!state.chats.length) {
+                            state.currentChatId = null;
+                        }
+                    } finally {
+                        this.saveState();
+                    }
+                },
+                async refreshChat(chatId) {
+                    try {
+                        const response = await fetch(`${API_BASE}/chats/${chatId}`);
+                        if (!response.ok) {
+                            return;
+                        }
+                        const data = await response.json();
+                        const normalized = {
+                            id: data.chat_id || chatId,
+                            title: data.title || 'Nova conversa',
+                            messages: (data.messages || []).map((msg) => ({
+                                role: msg.role,
+                                content: msg.content,
+                                type: 'text'
+                            }))
+                        };
+                        const index = state.chats.findIndex((chat) => chat.id === normalized.id);
+                        if (index >= 0) {
+                            state.chats[index] = normalized;
+                        } else {
+                            state.chats.push(normalized);
+                        }
+                        this.saveState();
+                    } catch (error) {
+                        console.error('Erro ao atualizar chat', error);
+                    }
+                },
+                async createChatRecord(titleSnippet = '') {
+                    const payload = titleSnippet ? { title: titleSnippet } : {};
+                    const response = await fetch(`${API_BASE}/chats`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    });
+                    if (!response.ok) {
+                        throw new Error(`Falha ao criar chat (${response.status})`);
+                    }
+                    const data = await response.json();
+                    const normalized = titleSnippet
+                        ? (titleSnippet.length > 30 ? `${titleSnippet.slice(0, 27)}...` : titleSnippet)
+                        : 'Nova conversa';
+                    const chatEntry = { id: data.chat_id, title: normalized || 'Nova conversa', messages: [] };
+                    state.chats.push(chatEntry);
+                    state.currentChatId = chatEntry.id;
+                    this.saveState();
+                    return chatEntry;
+                },
+                async createNewChat() {
+                    try {
+                        await this.createChatRecord('Nova conversa');
+                        ui.renderSidebar();
+                        ui.renderCurrentChat();
+                    } catch (error) {
+                        console.error('Não foi possível criar um novo chat', error);
+                    }
+                },
+                setMode(mode) {
+                    if (state.currentMode === mode) return;
+                    state.currentMode = mode;
+                    this.saveState();
+                    ui.updateForMode();
+                    if (!state.currentChatId) {
+                        ui.renderCurrentChat();
+                    }
+                },
+                addMessage(chatId, role, content, type = 'text') {
+                    const chat = state.chats.find((item) => item.id === chatId);
+                    if (!chat) return null;
+                    const normalizedRole = role === 'ai' ? 'assistant' : role;
+                    const message = { role: normalizedRole, content, type };
+                    chat.messages.push(message);
+                    this.saveState();
+                    return chat.messages.length - 1;
+                },
+                updateMessage(chatId, index, updates) {
+                    const chat = state.chats.find((item) => item.id === chatId);
+                    if (!chat || !chat.messages[index]) return;
+                    chat.messages[index] = { ...chat.messages[index], ...updates };
+                    this.saveState();
+                }
+            };
+
+            const handlers = {
+                async handleFormSubmit(event) {
+                    const messageText = DOM.chatInput.value.trim();
+                    if (!messageText) return;
+                    DOM.sendBtn.disabled = true;
+                    let chatData = state.chats.find((chat) => chat.id === state.currentChatId) || null;
+                    try {
+                        if (!chatData) {
+                            chatData = await app.createChatRecord(messageText);
+                            ui.renderSidebar();
+                        } else if (!chatData.title || chatData.title === 'Nova conversa') {
+                            const snippet = messageText.length > 30 ? `${messageText.slice(0, 27)}...` : messageText;
+                            chatData.title = snippet || chatData.title;
+                            app.saveState();
+                            ui.renderSidebar();
+                        }
+                    } catch (error) {
+                        console.error('Falha ao iniciar chat', error);
+                        DOM.sendBtn.disabled = false;
+                        return;
+                    }
+
+                    app.addMessage(state.currentChatId, 'user', messageText);
+                    const aiIndex = app.addMessage(state.currentChatId, 'ai', '_Processando..._');
+                    ui.renderCurrentChat();
+                    await chat.fetchResponse(messageText, aiIndex);
+                    ui.resetInput();
+                    DOM.sendBtn.disabled = true;
+                    handlers.handleInput();
+                },
+                handleInput() {
+                    DOM.chatInput.style.height = 'auto';
+                    DOM.chatInput.style.height = `${DOM.chatInput.scrollHeight}px`;
+                    const enabled = DOM.chatInput.value.trim() !== '';
+                    DOM.sendBtn.disabled = !enabled;
+                    DOM.sendBtn.classList.toggle('bg-blue-500', enabled);
+                    DOM.sendBtn.classList.toggle('text-white', enabled);
+                    DOM.sendBtn.classList.toggle('bg-gray-200', !enabled);
+                    DOM.sendBtn.classList.toggle('text-gray-400', !enabled);
+                },
+                handleKeydown(event) {
+                    if (event.key === 'Enter' && !event.shiftKey) {
+                        event.preventDefault();
+                        handlers.handleFormSubmit(event);
+                    }
+                },
+                async handleSidebarClick(event) {
+                    const chatItem = event.target.closest('[data-chat-id]');
+                    if (!chatItem) return;
+                    const id = chatItem.dataset.chatId;
+                    if (event.target.closest('.delete-btn')) {
+                        ui.showConfirmationModal({
+                            title: 'Apagar Chat',
+                            body: 'Tem certeza de que deseja apagar esta conversa? Esta ação não pode ser revertida.',
+                            confirmText: 'Apagar',
+                            onConfirm: () => { void chat.delete(id); }
+                        });
+                    } else {
+                        state.currentChatId = id;
+                        await app.refreshChat(id);
+                        if (window.innerWidth < 768) sidebar.closeMobile();
+                        ui.renderSidebar();
+                        ui.renderCurrentChat();
+                    }
+                },
+                handleScroll() {
+                    const isScrolledUp = DOM.chatContainer.scrollHeight - DOM.chatContainer.scrollTop > DOM.chatContainer.clientHeight + 150;
+                    DOM.scrollToBottomBtn.classList.toggle('hidden', !isScrolledUp);
+                },
+                async startNewChat() {
+                    if (window.innerWidth < 768) sidebar.closeMobile();
+                    state.currentChatId = null;
+                    await app.createNewChat();
+                },
+                async handleExamplePrompt(event) {
+                    const promptText = event.currentTarget.querySelector('p:first-child').textContent;
+                    DOM.chatInput.value = promptText;
+                    handlers.handleInput();
+                    await handlers.handleFormSubmit(new Event('submit', { cancelable: true }));
+                }
+            };
+
+            const chat = {
+                async fetchResponse(userInput, messageIndex) {
+                    const chatId = state.currentChatId;
+                    if (!chatId) return;
+                    try {
+                        const response = await fetch(`${API_BASE}/chats/${chatId}/messages`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ text: userInput })
+                        });
+                        if (!response.ok) {
+                            throw new Error(`Erro ${response.status}`);
+                        }
+                        const data = await response.json();
+                        const normalizedMessages = (data.messages || []).map((msg) => ({
+                            role: msg.role,
+                            content: msg.content,
+                            type: 'text'
+                        }));
+                        if (normalizedMessages.length) {
+                            const lastMessage = normalizedMessages[normalizedMessages.length - 1];
+                            if (lastMessage.role === 'assistant') {
+                                const stepsText = (data.steps || []).map((step) => `• ${step}`).join('\n');
+                                if (stepsText) {
+                                    lastMessage.content = `${lastMessage.content}\n\n${stepsText}`.trim();
+                                }
+                            }
+                        }
+                        const chatData = state.chats.find((item) => item.id === chatId);
+                        if (chatData) {
+                            chatData.messages = normalizedMessages;
+                            if (data.title && chatData.title !== data.title) {
+                                chatData.title = data.title;
+                                ui.renderSidebar();
+                            }
+                        } else {
+                            state.chats.push({
+                                id: data.chat_id || chatId,
+                                title: data.title || 'Nova conversa',
+                                messages: normalizedMessages
+                            });
+                            ui.renderSidebar();
+                        }
+                    } catch (error) {
+                        console.error('Erro ao contactar o servidor', error);
+                        app.updateMessage(chatId, messageIndex, { content: 'Ocorreu um erro ao contactar o servidor.' });
+                    } finally {
+                        app.saveState();
+                        ui.renderCurrentChat();
+                    }
+                },
+                async delete(chatId) {
+                    const previousChats = state.chats.map((chat) => ({
+                        ...chat,
+                        messages: chat.messages.map((message) => ({ ...message }))
+                    }));
+                    const previousCurrent = state.currentChatId;
+
+                    try {
+                        const response = await fetch(`${API_BASE}/chats/${chatId}`, { method: 'DELETE' });
+                        if (!response.ok && response.status !== 404) {
+                            throw new Error(`Erro ${response.status}`);
+                        }
+                    } catch (error) {
+                        console.error('Erro ao remover chat do servidor', error);
+                        state.chats = previousChats;
+                        state.currentChatId = previousCurrent;
+                        app.saveState();
+                        ui.renderSidebar();
+                        ui.renderCurrentChat();
+                        return;
+                    }
+
+                    state.chats = previousChats.filter((chat) => chat.id !== chatId);
+                    if (state.currentChatId === chatId) {
+                        state.currentChatId = state.chats.length ? state.chats[0].id : null;
+                    }
+                    app.saveState();
+                    ui.renderSidebar();
+                    ui.renderCurrentChat();
+                }
+            };
+
+            const ui = {
+                renderCurrentChat() {
+                    DOM.chatContainer.innerHTML = '';
+                    if (!state.currentChatId) {
+                        this.renderInitialView();
+                        return;
+                    }
+                    const chatData = state.chats.find((chat) => chat.id === state.currentChatId);
+                    if (!chatData || chatData.messages.length === 0) {
+                        this.renderInitialView();
+                        return;
+                    }
+                    let lastElement = null;
+                    chatData.messages.forEach((msg, index) => {
+                        if (msg.type === 'text') {
+                            lastElement = this.appendTextMessage(msg);
+                        } else if (msg.type === 'agent_task') {
+                            lastElement = this.appendAgentTaskMessage(msg, index);
+                        }
+                    });
+                    DOM.chatContainer.scrollTop = DOM.chatContainer.scrollHeight;
+                    return lastElement;
+                },
+                renderInitialView() {
+                    const isAgent = state.currentMode === 'agent';
+                    const title = isAgent ? 'Pronto para executar tarefas?' : 'Tudo pronto? Então vamos lá!';
+                    const prompts = isAgent ? [
+                        { title: 'Navegue para o site da Amazon', desc: 'e procure por livros de ficção científica.' },
+                        { title: 'Mostre o PDF', desc: 'no URL https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf' },
+                        { title: 'Analise este ficheiro', desc: 'e resuma os pontos principais.' },
+                        { title: 'Crie um novo ficheiro de código', desc: 'com uma função Python para calcular o fatorial.' }
+                    ] : [
+                        { title: 'Crie um poema', desc: 'sobre a beleza da tecnologia.' },
+                        { title: 'Me dê ideias', desc: 'para um projeto de fim de semana.' },
+                        { title: 'Escreva um código', desc: 'de uma função em Python que some dois números.' },
+                        { title: 'Explique o que é', desc: 'computação quântica em termos simples.' }
+                    ];
+                    const promptsHtml = prompts.map((prompt) => `
+                        <button class="example-prompt text-left p-4 border border-custom rounded-lg btn-hover">
+                            <p class="font-semibold text-primary">${prompt.title}</p>
+                            <p class="text-sm text-secondary">${prompt.desc}</p>
+                        </button>
+                    `).join('');
+                    DOM.chatContainer.innerHTML = `
+                        <div class="flex flex-col items-center justify-center h-full pb-8 text-center">
+                            <div class="mb-8">
+                                <div class="w-16 h-16 rounded-full bg-gradient-to-tr from-purple-500 to-blue-500 flex items-center justify-center mx-auto mb-4">
+                                    <i class="fa-solid ${isAgent ? 'fa-bolt' : 'fa-star'} text-white text-2xl"></i>
+                                </div>
+                                <h1 class="text-2xl font-semibold text-primary">${title}</h1>
+                            </div>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-2xl">
+                                ${promptsHtml}
+                            </div>
+                        </div>
+                    `;
+                    DOM.chatContainer.querySelectorAll('.example-prompt').forEach((prompt) => {
+                        prompt.addEventListener('click', handlers.handleExamplePrompt);
+                    });
+                },
+                renderSidebar() {
+                    DOM.recentChatsContainer.innerHTML = '';
+                    if (!state.chats.length) {
+                        DOM.recentChatsContainer.innerHTML = '<div class="p-3 text-sm text-secondary sidebar-text">Nenhum chat recente...</div>';
+                        return;
+                    }
+                    state.chats.slice().reverse().forEach((chat) => {
+                        const item = document.createElement('a');
+                        item.href = '#';
+                        item.className = `sidebar-item flex items-center justify-between p-3 rounded-lg text-sm btn-hover ${chat.id === state.currentChatId ? 'btn-active' : ''}`;
+                        item.dataset.chatId = chat.id;
+                        item.innerHTML = `
+                            <span class="truncate sidebar-text">${chat.title || 'Nova conversa'}</span>
+                            <button class="delete-btn sidebar-text text-secondary hover:text-red-500 p-1" title="Apagar chat"><i class="fa-solid fa-trash-can"></i></button>
+                        `;
+                        DOM.recentChatsContainer.appendChild(item);
+                    });
+                },
+                updateForMode() {
+                    [DOM.chatModeBtn, DOM.agentModeBtn].forEach((btn) => {
+                        const isActive = btn.dataset.mode === state.currentMode;
+                        btn.classList.toggle('bg-white', isActive);
+                        btn.classList.toggle('shadow-sm', isActive);
+                        btn.classList.toggle('text-secondary', !isActive);
+                        btn.classList.toggle('text-primary', isActive);
+                    });
+                    DOM.chatInput.placeholder = state.currentMode === 'agent'
+                        ? 'Dê uma tarefa ao agente...'
+                        : 'Pergunte alguma coisa...';
+                },
+                appendTextMessage(message) {
+                    const container = document.createElement('div');
+                    container.className = 'flex mb-6';
+                    if (message.role === 'user') {
+                        container.classList.add('justify-end');
+                        container.innerHTML = `<div class="user-message rounded-lg p-3 w-11/12 max-w-lg"><p>${message.content.replace(/\n/g, '<br>')}</p></div>`;
+                    } else {
+                        container.classList.add('justify-start', 'ai-message-container');
+                        container.innerHTML = `
+                            <div class="w-8 h-8 rounded-full bg-gradient-to-tr from-purple-500 to-blue-500 flex items-center justify-center flex-shrink-0 mr-3 mt-1"><i class="fa-solid fa-star text-white text-sm"></i></div>
+                            <div class="ai-message-bubble rounded-lg p-4 w-11/12 max-w-2xl border border-custom">
+                                <div class="flex justify-end mb-2"><button class="copy-btn p-2 rounded-lg btn-hover text-secondary text-xs flex items-center gap-2" title="Copiar texto"><i class="fa-regular fa-copy"></i>Copiar</button></div>
+                                <div class="prose max-w-none text-primary">${marked.parse(message.content || '')}</div>
+                            </div>
+                        `;
+                        const copyBtn = container.querySelector('.copy-btn');
+                        copyBtn.addEventListener('click', () => {
+                            const contentToCopy = container.querySelector('.prose').innerText;
+                            navigator.clipboard.writeText(contentToCopy).then(() => {
+                                copyBtn.innerHTML = '<i class="fa-solid fa-check"></i>Copiado!';
+                                setTimeout(() => { copyBtn.innerHTML = '<i class="fa-regular fa-copy"></i>Copiar'; }, 2000);
+                            }).catch((error) => {
+                                console.error('Não foi possível copiar', error);
+                            });
+                        });
+                    }
+                    DOM.chatContainer.appendChild(container);
+                    return container;
+                },
+                appendAgentTaskMessage(message, index) {
+                    const container = document.createElement('div');
+                    container.className = 'flex justify-start mb-6';
+                    container.innerHTML = `
+                        <div class="w-8 h-8 rounded-full bg-gray-500 flex items-center justify-center flex-shrink-0 mr-3 mt-1"><i class="fa-solid fa-desktop text-white text-sm"></i></div>
+                        <div class="rounded-lg p-3 w-11/12 max-w-lg border border-custom bg-ai-msg-bg">
+                            <p class="font-semibold text-primary">${message.content?.title || 'Tarefa do agente'}</p>
+                            <p class="text-sm text-secondary">${message.content?.status || ''}</p>
+                        </div>
+                    `;
+                    DOM.chatContainer.appendChild(container);
+                    return container;
+                },
+                resetInput() {
+                    DOM.chatInput.value = '';
+                    DOM.chatInput.style.height = 'auto';
+                },
+                showConfirmationModal({ title, body, confirmText = 'Confirmar', onConfirm }) {
+                    const modalId = `modal-${Date.now()}`;
+                    const modalHtml = `
+                        <div id="${modalId}" class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 opacity-0 pointer-events-none">
+                            <div class="modal-content bg-main rounded-lg shadow-xl p-6 w-full max-w-md transform scale-95">
+                                <h3 class="text-lg font-semibold text-primary">${title}</h3>
+                                <p class="mt-2 text-secondary">${body}</p>
+                                <div class="mt-6 flex justify-end gap-3">
+                                    <button class="modal-cancel-btn px-4 py-2 rounded-md text-sm font-medium btn-hover">Cancelar</button>
+                                    <button class="modal-confirm-btn px-4 py-2 rounded-md text-sm font-medium bg-blue-600 text-white hover:bg-blue-700">${confirmText}</button>
+                                </div>
+                            </div>
+                        </div>
+                    `;
+                    DOM.modalsContainer.insertAdjacentHTML('beforeend', modalHtml);
+                    const modal = document.getElementById(modalId);
+                    const content = modal.querySelector('.modal-content');
+                    const confirmBtn = modal.querySelector('.modal-confirm-btn');
+                    const cancelBtn = modal.querySelector('.modal-cancel-btn');
+                    const closeModal = () => {
+                        modal.classList.add('opacity-0');
+                        content.classList.add('scale-95');
+                        setTimeout(() => modal.remove(), 300);
+                    };
+                    confirmBtn.onclick = () => {
+                        onConfirm?.();
+                        closeModal();
+                    };
+                    cancelBtn.onclick = closeModal;
+                    setTimeout(() => {
+                        modal.classList.remove('opacity-0', 'pointer-events-none');
+                        content.classList.remove('scale-95');
+                    }, 10);
+                }
+            };
+
+            const sidebar = {
+                init() {
+                    if (localStorage.getItem('sidebar_collapsed') === 'true') {
+                        DOM.sidebar.classList.replace('w-64', 'w-20');
+                        document.querySelectorAll('.sidebar-text').forEach((el) => el.classList.add('hidden'));
+                        DOM.sidebar.querySelector('#sidebar-toggle i').classList.replace('fa-chevron-left', 'fa-chevron-right');
+                    }
+                    const toggleBtn = DOM.sidebar.querySelector('#sidebar-toggle');
+                    toggleBtn.addEventListener('click', this.toggle);
+                },
+                toggle() {
+                    DOM.sidebar.classList.toggle('w-64');
+                    DOM.sidebar.classList.toggle('w-20');
+                    const isCollapsed = DOM.sidebar.classList.contains('w-20');
+                    localStorage.setItem('sidebar_collapsed', isCollapsed);
+                    document.querySelectorAll('.sidebar-text').forEach((el) => el.classList.toggle('hidden'));
+                    const icon = DOM.sidebar.querySelector('#sidebar-toggle i');
+                    icon.classList.toggle('fa-chevron-left', !isCollapsed);
+                    icon.classList.toggle('fa-chevron-right', isCollapsed);
+                },
+                openMobile() {
+                    DOM.sidebar.classList.remove('-translate-x-full');
+                    DOM.sidebarBackdrop.classList.remove('hidden');
+                },
+                closeMobile() {
+                    DOM.sidebar.classList.add('-translate-x-full');
+                    DOM.sidebarBackdrop.classList.add('hidden');
+                }
+            };
+
+            app.init();
+        });
+    </script>
+</body>
+</html>

--- a/app/web/static/index.html
+++ b/app/web/static/index.html
@@ -297,7 +297,7 @@
                 },
                 async createNewChat() {
                     try {
-                        await this.createChatRecord('Nova conversa');
+                        await this.createChatRecord();
                         ui.renderSidebar();
                         ui.renderCurrentChat();
                     } catch (error) {


### PR DESCRIPTION
## Summary
- guard the FastAPI chat registry with an asyncio lock and snapshot messages before returning them to clients
- add helpers on `ChatSession` so list/get/message endpoints reuse a safe serialized view of the current conversation
- update the browser client to persist the initial chat selection and roll back UI state when chat deletion fails on the server

## Testing
- python -m compileall app/web/server.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4c8a38088324b4608255df8522b9